### PR TITLE
Add multi-cluster support to ASM client

### DIFF
--- a/client/src/components/FileManager.js
+++ b/client/src/components/FileManager.js
@@ -5,7 +5,6 @@ import $ from 'elfinder/elfinder';
 import Uploader from 'plupload/Uploader';
 import NoTargetsMessage from 'storage/components/NoTargetsMessage';
 import { Panel } from 'react-bootstrap';
-import { storageToHash } from 'storage/utils';
 import Icon from 'components/Icon';
 const Base64 = require('js-base64').Base64;
 

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -36,6 +36,21 @@ class Header extends React.Component {
 
   navbarRight() {
     const {currentStorage, storageHosts, logout, redirectTo} = this.props;
+
+    const StorageMenuItem = ({host}) => {
+      return (
+        <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)} iconName="hdd-o">{host.name} (<em>{host.username}</em>)</MenuItem>
+      );
+    };
+
+    const storageMenuItems = (hosts) => _(hosts).map(
+      (host) => (<StorageMenuItem host={host} />)
+    ).value();
+
+    const LogoutMenuItem = ({storage}) => <MenuItem onClick={() => {logout(storage)}} iconName="sign-out">Log out of {storage.name}</MenuItem>;
+
+    const MainMenuItem = ({}) => <MenuItem onClick={() => redirectTo('/')} iconName="arrow-return">Back to main menu</MenuItem>;
+
     if (currentStorage) {
       const currentText = <span>Logged in as <strong>{currentStorage.username}</strong> to <strong>{currentStorage.name}</strong> (<em>{currentStorage.ip}:{currentStorage.auth_port}</em>)</span>;
       const otherStorageHosts = _(storageHosts).reject((host) => host.id == currentStorage.id).value();
@@ -44,8 +59,8 @@ class Header extends React.Component {
         return (
           <Nav pullRight>
             <NavDropdown title={currentText} id="navbar-right-menu">
-              <MenuItem onClick={() => {logout(currentStorage)}} iconName="sign-out">Log out of {currentStorage.name}</MenuItem>
-              <MenuItem onClick={() => redirectTo('/')} iconName="arrow-return">Back to main menu</MenuItem>
+              <LogoutMenuItem storage={currentStorage} />
+              <MainMenuItem />
             </NavDropdown>
 
           </Nav>
@@ -56,16 +71,10 @@ class Header extends React.Component {
         <Nav pullRight>
           <NavDropdown title={currentText} id="navbar-right-menu">
             <MenuItem header>Also logged in to:</MenuItem>
-            {_(otherStorageHosts).map(
-              (host) => {
-                return (
-                  <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)} iconName="hdd-o">{host.name} (<em>{host.username}</em>)</MenuItem>
-                );
-              }
-            ).value()}
+            {storageMenuItems(otherStorageHosts)}
             <MenuItem divider />
-            <MenuItem onClick={() => {logout(currentStorage)}} iconName="sign-out">Log out of {currentStorage.name}</MenuItem>
-            <MenuItem onClick={() => redirectTo('/')} iconName="arrow-return">Back to main menu</MenuItem>
+            <LogoutMenuItem storage={currentStorage} />
+            <MainMenuItem />
           </NavDropdown>
 
         </Nav>
@@ -77,13 +86,7 @@ class Header extends React.Component {
         <Nav pullRight>
           <NavDropdown title={titleText} id="navbar-right-menu">
             <MenuItem header>Logged in to:</MenuItem>
-            {_(storageHosts).map(
-              (host) => {
-                return (
-                  <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)} iconName="hdd-o">{host.name} (<em>{host.username}</em>)</MenuItem>
-                );
-              }
-            ).value()}
+            {storageMenuItems(storageHosts)}
           </NavDropdown>
         </Nav>
       );

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,6 +1,6 @@
-
+import _ from 'lodash';
 import React, {PropTypes} from 'react';
-import { Nav, NavItem } from 'react-bootstrap';
+import { MenuItem, Nav, NavDropdown } from 'react-bootstrap';
 import { Header as FlightHeader, NavItemLink, Icon } from 'flight-common';
 
 class Header extends React.Component {
@@ -19,16 +19,43 @@ class Header extends React.Component {
   }
 
   navbarRight() {
-    const {currentStorage, logout} = this.props;
+    const {currentStorage, storageHosts, logout, redirectTo} = this.props;
     if (currentStorage) {
+      const currentText = <span>Logged in as <strong>{currentStorage.username}</strong> to <strong>{currentStorage.name}</strong> (<em>{currentStorage.ip}:{currentStorage.auth_port}</em>)</span>;
+      const otherStorageHosts = _(storageHosts).reject((host) => host.id == currentStorage.id).value();
+
+      if (otherStorageHosts.length == 0) {
+        return (
+          <Nav pullRight>
+            <NavDropdown title={currentText} id="navbar-right-menu">
+              <MenuItem onClick={() => {logout(currentStorage)}}>
+                Log out of {currentStorage.name} <Icon name="sign-out" />
+              </MenuItem>
+              <MenuItem onClick={() => redirectTo('/')}>Back to main menu</MenuItem>
+            </NavDropdown>
+
+          </Nav>
+        );
+      }
+
       return (
         <Nav pullRight>
-          <NavItem>
-            Logged in as <strong>{currentStorage.username}</strong> to {currentStorage.ip}:{currentStorage.auth_port}&nbsp;
-          </NavItem>
-          <NavItem onClick={() => {logout(currentStorage)}}>
-            Log out <Icon name="sign-out" />
-          </NavItem>
+          <NavDropdown title={currentText} id="navbar-right-menu">
+            <MenuItem header>Also logged in to:</MenuItem>
+            {_(otherStorageHosts).map(
+              (host) => {
+                return (
+                  <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)}>{host.name} (<em>{host.username}</em>)</MenuItem>
+                );
+              }
+            ).value()}
+            <MenuItem divider />
+            <MenuItem onClick={() => {logout(currentStorage)}}>
+              Log out of {currentStorage.name} <Icon name="sign-out" />
+            </MenuItem>
+            <MenuItem onClick={() => redirectTo('/')}>Back to main menu</MenuItem>
+          </NavDropdown>
+
         </Nav>
       );
     }

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,7 +1,23 @@
 import _ from 'lodash';
 import React, {PropTypes} from 'react';
-import { MenuItem, Nav, NavDropdown } from 'react-bootstrap';
+import { MenuItem as BsMenuItem, Nav, NavDropdown } from 'react-bootstrap';
 import { Header as FlightHeader, NavItemLink, Icon } from 'flight-common';
+
+const MenuItem = ({onClick, iconName, children, header, divider}) => {
+  if (header) {
+    return <BsMenuItem header>{children}</BsMenuItem>;
+  }
+  if (divider) {
+    return <BsMenuItem divider />;
+  }
+
+  return (
+    <BsMenuItem onClick={onClick}>
+      <Icon name={iconName || "fw"} />
+      {children}
+    </BsMenuItem>
+  );
+};
 
 class Header extends React.Component {
   render() {
@@ -28,10 +44,8 @@ class Header extends React.Component {
         return (
           <Nav pullRight>
             <NavDropdown title={currentText} id="navbar-right-menu">
-              <MenuItem onClick={() => {logout(currentStorage)}}>
-                Log out of {currentStorage.name} <Icon name="sign-out" />
-              </MenuItem>
-              <MenuItem onClick={() => redirectTo('/')}>Back to main menu</MenuItem>
+              <MenuItem onClick={() => {logout(currentStorage)}} iconName="sign-out">Log out of {currentStorage.name}</MenuItem>
+              <MenuItem onClick={() => redirectTo('/')} iconName="arrow-return">Back to main menu</MenuItem>
             </NavDropdown>
 
           </Nav>
@@ -45,15 +59,13 @@ class Header extends React.Component {
             {_(otherStorageHosts).map(
               (host) => {
                 return (
-                  <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)}>{host.name} (<em>{host.username}</em>)</MenuItem>
+                  <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)} iconName="hdd-o">{host.name} (<em>{host.username}</em>)</MenuItem>
                 );
               }
             ).value()}
             <MenuItem divider />
-            <MenuItem onClick={() => {logout(currentStorage)}}>
-              Log out of {currentStorage.name} <Icon name="sign-out" />
-            </MenuItem>
-            <MenuItem onClick={() => redirectTo('/')}>Back to main menu</MenuItem>
+            <MenuItem onClick={() => {logout(currentStorage)}} iconName="sign-out">Log out of {currentStorage.name}</MenuItem>
+            <MenuItem onClick={() => redirectTo('/')} iconName="arrow-return">Back to main menu</MenuItem>
           </NavDropdown>
 
         </Nav>

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -71,6 +71,23 @@ class Header extends React.Component {
         </Nav>
       );
     }
+    else if (storageHosts.length > 0) {
+      const titleText = `Logged in to ${storageHosts.length} collection${storageHosts.length == 1 ? '' : 's'}`;
+      return (
+        <Nav pullRight>
+          <NavDropdown title={titleText} id="navbar-right-menu">
+            <MenuItem header>Logged in to:</MenuItem>
+            {_(storageHosts).map(
+              (host) => {
+                return (
+                  <MenuItem onClick={() => redirectTo(`/storage/${host.id}/`)} iconName="hdd-o">{host.name} (<em>{host.username}</em>)</MenuItem>
+                );
+              }
+            ).value()}
+          </NavDropdown>
+        </Nav>
+      );
+    }
     else {
       return null;
     }

--- a/client/src/components/pages/StorageSelectionPage.js
+++ b/client/src/components/pages/StorageSelectionPage.js
@@ -11,9 +11,10 @@ export default class StorageSelectionPage extends React.Component {
     const {
       storage: {hosts},
       authenticate,
+      logout,
     } = this.props;
 
-    const clusterSelectionBoxProps = {authenticate};
+    const clusterSelectionBoxProps = {authenticate, logout};
 
     const storageAvailableMessage = _.isEmpty(hosts) ?
       (

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -8,6 +8,7 @@ import Header from 'components/Header';
 import { Footer, LoadingPage } from 'flight-common';
 import * as notificationActions from 'notification/actions';
 import * as storageActions from 'storage/actions';
+import * as routerActions from 'actions/router';
 import NotificationModals from 'notification/components/NotificationModals';
 import {appSelector} from 'selectors';
 
@@ -98,5 +99,6 @@ export default connect(
   {
     closeNotificationModal: notificationActions.closeModal,
     logout: storageActions.logout,
+    redirectTo: routerActions.redirectTo
   }
 )(App);

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -99,6 +99,6 @@ export default connect(
   {
     closeNotificationModal: notificationActions.closeModal,
     logout: storageActions.logout,
-    redirectTo: routerActions.redirectTo
+    redirectTo: routerActions.redirectTo,
   }
 )(App);

--- a/client/src/modules/notification/errorMessageCustomization.js
+++ b/client/src/modules/notification/errorMessageCustomization.js
@@ -1,6 +1,8 @@
 
 import React from 'react';
 
+import * as storageActionTypes from 'storage/actionTypes';
+
 import {ContactCustomerSupport} from 'flight-common';
 
 import MessageGenerator from "./MessageGenerator";
@@ -69,18 +71,15 @@ export function setupDefaultErrorMessageGenerators(generatorsMap) {
 // customize as they see fit.
 //
 export function addActionTypeCustomizations(generatorsMap) {
-  generatorsMap
-  // generatorsMap.
-  //
-  //   customizeMessage(
-  //     401,
-  //     clusterActionTypes.AUTHENTICATE,
-  //     {
-  //       title: 'Authentication failure',
-  //       content: `The provided username and/or password are incorrect for the
-  //         selected cluster. Please correct these and try again.`,
-  //     }
-  //   );
+  generatorsMap.customizeMessage(
+    401,
+    storageActionTypes.AUTHENTICATE,
+    {
+      title: 'Authentication failure',
+      content: `The provided username and/or password are incorrect for the
+           selected storage collection. Please correct these and try again.`,
+    }
+  );
 
 }
 

--- a/client/src/modules/storage/components/StorageLoginForm.js
+++ b/client/src/modules/storage/components/StorageLoginForm.js
@@ -32,10 +32,10 @@ class StorageLoginForm extends Component {
     const authenticateWithStorageHost = _.partial(authenticate, host);
     const incomplete = !(username.value && password.value);
 
-    const submitButtonIcon = submitting ? "cluster-authenticating" : "cluster";
+    const submitButtonIcon = submitting ? "aam-cluster-authenticating" : "aam-cluster";
     const submitButtonText = (
       <span>
-        Login&nbsp;&nbsp;<Icon name={submitButtonIcon}/>
+        Log in&nbsp;&nbsp;<Icon name={submitButtonIcon}/>
       </span>
     );
 

--- a/client/src/modules/storage/components/StorageSelectionCard.js
+++ b/client/src/modules/storage/components/StorageSelectionCard.js
@@ -2,40 +2,89 @@
 import React from 'react';
 import FlipCard from 'react-flipcard';
 
+import { Button } from 'react-bootstrap';
+import { ButtonLink, Icon } from 'flight-common';
+
 import StorageLoginForm, {storageLoginFormName} from 'storage/components/StorageLoginForm';
 
 class StorageSelectionCard extends React.Component {
   render() {
-    const {authenticate, item} = this.props;
+    const {authenticate, item, logout} = this.props;
 
-    const form = storageLoginFormName(item);
-
-    return (
-      <div
-        className="flip-selection-box"
-        >
-        <FlipCard>
-          <div className="flip-selection-box-front">
-            {item.name}
-            <p>
-              <em>Click to log in</em>
-            </p>
-          </div>
-          <div className="flip-selection-box-back">
-            <p>
-              <strong>{item.name}</strong>
-            </p>
-            <StorageLoginForm
-              authenticate={authenticate}
-              host={item}
-              form={form}
-            />
-          </div>
-        </FlipCard>
-      </div>
-    );
+    if (item.username) {
+      return (
+        <AuthenticatedStorageSelectionCard
+          logout={logout}
+          item={item}
+        />
+      );
+    }
+    else {
+      return (
+        <UnauthenticatedStorageSelectionCard
+          authenticate={authenticate}
+          item={item}
+        />
+      );
+    }
   }
 }
+
+const UnauthenticatedStorageSelectionCard = ({item, authenticate}) => {
+  const form = storageLoginFormName(item);
+
+  return (
+    <div
+      className="flip-selection-box"
+    >
+      <FlipCard>
+        <div className="flip-selection-box-front">
+          {item.name}
+          <p>
+            <em>Click to log in</em>
+          </p>
+        </div>
+        <div className="flip-selection-box-back">
+          <p>
+            <strong>{item.name}</strong>
+          </p>
+          <StorageLoginForm
+            authenticate={authenticate}
+            host={item}
+            form={form}
+          />
+        </div>
+      </FlipCard>
+    </div>
+  );
+};
+
+const AuthenticatedStorageSelectionCard = ({item, logout}) => {
+  return (
+    <div
+      className="static-selection-box"
+    >
+      <p>
+        <strong>{item.name}</strong>
+      </p>
+      <p>
+        Logged in as <em>{item.username}</em>
+      </p>
+      <div className="selection-box-button-container">
+        <div className="selection-box-button-inner-container">
+          <ButtonLink to={`/storage/${item.id}/`} bsStyle="success">
+            View Storage
+          </ButtonLink>
+          <Button bsStyle="danger"
+            onClick={() => logout(item)}
+          >
+            Log out <Icon name="sign-out" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default StorageSelectionCard
 

--- a/client/src/modules/storage/utils.js
+++ b/client/src/modules/storage/utils.js
@@ -1,9 +1,0 @@
-const Base64 = require('js-base64').Base64;
-
-export const storageToHash = (storage) => {
-  return Base64.encode(storage.address);
-};
-
-export const hashToStorageAddress = (hash) => {
-  return Base64.decode(hash);
-}

--- a/client/src/selectors.js
+++ b/client/src/selectors.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {createSelector} from 'reselect';
 
 const uiState = (state) => state.ui;
@@ -48,16 +49,25 @@ export const currentStorageSelector = createSelector(
 
 );
 
+const authenticatedStorageSelector = createSelector(
+  storageState,
+  (storage) => {
+    return _(storage.hosts).filter((storage) => !!storage.username).value()
+  }
+);
+
 export const appSelector = createSelector(
   notificationsSelector,
   uiState,
   currentStorageSelector,
+  authenticatedStorageSelector,
 
-  (notifications, ui, currentStorage) => {
+  (notifications, ui, currentStorage, storageHosts) => {
     return {
       notifications,
       ui,
       currentStorage,
+      storageHosts,
     }
   }
 );

--- a/client/src/styles/main.scss
+++ b/client/src/styles/main.scss
@@ -23,4 +23,8 @@
     background-color: $c-primary-color--dark;
     margin: 9px;
   }
+
+  .flight-icon {
+    padding-right: 10px;
+  }
 }

--- a/client/src/styles/main.scss
+++ b/client/src/styles/main.scss
@@ -6,3 +6,21 @@
 .navbar-default .navbar-text {
   color: white;
 }
+
+.dropdown-header {
+    color: #CCCCCC;
+}
+
+.dropdown-menu {
+  font-size: inherit;
+  min-width: 350px;
+  li a {
+    padding-top: 15px;
+    padding-bottom: 15px;
+  }
+
+  .divider {
+    background-color: $c-primary-color--dark;
+    margin: 9px;
+  }
+}

--- a/server/app/controllers/api/v1/storage_controller.rb
+++ b/server/app/controllers/api/v1/storage_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::StorageController < ApplicationController
 
     all_collections.each do |id, collection|
       our_collection = collection.dup
-      if authentications.key?(id)
+      if authentications && authentications.key?(id)
         our_collection['username'] = authentications[id]
 
         daemon = AlcesStorageManager::daemon_for(id)


### PR DESCRIPTION
This PR builds on work in https://github.com/alces-software/alces-storage-manager/pull/6 to improve the web UI's support for multiple storage hosts.

The selection screen now distinguishes between storage collections we have authenticated with and those we have not. A dropdown menu allows the user to quickly switch between collections they have authenticated with, or to log out.

Additionally, a couple of bugs with multi-cluster support on the server side were fixed.
